### PR TITLE
DiodeClipper: fix Windows compiler error and slightly different file loading

### DIFF
--- a/Example_Circuits/DiodeClipper/VST/DiodeClipper/Source/PluginProcessor.cpp
+++ b/Example_Circuits/DiodeClipper/VST/DiodeClipper/Source/PluginProcessor.cpp
@@ -24,6 +24,15 @@ DiodeClipperAudioProcessor::DiodeClipperAudioProcessor()
                        )
 #endif
 {
+    FileChooser fileChooser ("Select circuit json", File(), "*.json");
+
+    while (! jsonFile.existsAsFile())
+    {
+        if (fileChooser.browseForFileToOpen())
+            jsonFile = fileChooser.getResult();
+        else
+            DBG ("Please choose a file that exists...");
+    }
 }
 
 DiodeClipperAudioProcessor::~DiodeClipperAudioProcessor()
@@ -97,7 +106,7 @@ void DiodeClipperAudioProcessor::prepareToPlay (double sampleRate, int samplesPe
 {
     // Use this method as the place to do any pre-playback
     // initialisation that you need..
-    stateSpaceProcessor = std::make_unique<StateSpaceProcessor>("/abs/path/to/file.json", sampleRate);
+    stateSpaceProcessor = std::make_unique<StateSpaceProcessor>(jsonFile.getFullPathName().toStdString(), sampleRate);
     stateSpaceProcessor->printMatrices();
 }
 

--- a/Example_Circuits/DiodeClipper/VST/DiodeClipper/Source/PluginProcessor.h
+++ b/Example_Circuits/DiodeClipper/VST/DiodeClipper/Source/PluginProcessor.h
@@ -57,6 +57,8 @@ public:
 
 private:
     std::unique_ptr<StateSpaceProcessor> stateSpaceProcessor;
+
+    File jsonFile;
     
 public:
     const std::unique_ptr<StateSpaceProcessor>& getStateSpaceProcessor() const;

--- a/Example_Circuits/RLC_LowpassFilter/VST/RLCLowPassFilter/Source/CircuitParser.cpp
+++ b/Example_Circuits/RLC_LowpassFilter/VST/RLCLowPassFilter/Source/CircuitParser.cpp
@@ -20,10 +20,10 @@
 CircuitParser::CircuitParser(std::string jsonPath){
 
     std::string temp = jsonPath;
-    char pathAsChars[temp.length()];
-    strcpy(pathAsChars, temp.c_str());
+    std::unique_ptr<char[]> pathAsChars (new char[temp.length()]);
+    strcpy(pathAsChars.get(), temp.c_str());
     
-    std::ifstream i(pathAsChars, std::ifstream::in); // Get json filepath from the console
+    std::ifstream i(pathAsChars.release(), std::ifstream::in); // Get json filepath from the console
 
     nlohmann::json jsonData;
 

--- a/JUCE/NDKCircuitTemplate/README.md
+++ b/JUCE/NDKCircuitTemplate/README.md
@@ -1,10 +1,1 @@
-How to add Eigen to a JUCE project on mac.
 
-1. Download Eigen using Brew
-
-3. In the .jucer project file, go to "Project Settings" and "Header Search Paths" and add "/usr/local/include/eigen3/Eigen".
-
-4. In your C++ file, add:
-
-
-  #include <Eigen> 

--- a/JUCE/NDKCircuitTemplate/Source/CircuitParser.cpp
+++ b/JUCE/NDKCircuitTemplate/Source/CircuitParser.cpp
@@ -20,10 +20,10 @@
 CircuitParser::CircuitParser(std::string jsonPath){
 
     std::string temp = jsonPath;
-    char pathAsChars[temp.length()];
-    strcpy(pathAsChars, temp.c_str());
+    std::unique_ptr<char[]> pathAsChars (new char[temp.length()]);
+    strcpy(pathAsChars.get(), temp.c_str());
     
-    std::ifstream i(pathAsChars, std::ifstream::in); // Get json filepath from the console
+    std::ifstream i(pathAsChars.release(), std::ifstream::in); // Get json filepath from the console
 
     nlohmann::json jsonData;
 

--- a/JUCE/NDKCircuitTemplate/Source/PluginProcessor.cpp
+++ b/JUCE/NDKCircuitTemplate/Source/PluginProcessor.cpp
@@ -24,6 +24,15 @@ NdkcircuitTemplateAudioProcessor::NdkcircuitTemplateAudioProcessor()
                        )
 #endif
 {
+    FileChooser fileChooser ("Select circuit json", File(), "*.json");
+
+    while (! jsonFile.existsAsFile())
+    {
+        if (fileChooser.browseForFileToOpen())
+            jsonFile = fileChooser.getResult();
+        else
+            DBG ("Please choose a file that exists...");
+    }
 }
 
 NdkcircuitTemplateAudioProcessor::~NdkcircuitTemplateAudioProcessor()
@@ -95,7 +104,7 @@ void NdkcircuitTemplateAudioProcessor::changeProgramName (int index, const Strin
 //==============================================================================
 void NdkcircuitTemplateAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
 {
-    stateSpaceProcessor = std::make_unique<StateSpaceProcessor>("/Users/danielstrubig 1/Documents/Project Spring19/NDKFramework/Evaluation/WahWah/Spice/WahWahPot.json", sampleRate);
+    stateSpaceProcessor = std::make_unique<StateSpaceProcessor>(jsonFile.getFullPathName().toStdString(), sampleRate);
     stateSpaceProcessor->printMatrices();
 }
 

--- a/JUCE/NDKCircuitTemplate/Source/PluginProcessor.h
+++ b/JUCE/NDKCircuitTemplate/Source/PluginProcessor.h
@@ -57,8 +57,9 @@ public:
     void setStateInformation (const void* data, int sizeInBytes) override;
 
 private:
-
     std::unique_ptr<StateSpaceProcessor> stateSpaceProcessor;
+    File jsonFile;
+    
 public:
     const std::unique_ptr<StateSpaceProcessor>& getStateSpaceProcessor() const;
 


### PR DESCRIPTION
Fixed some issues for compiling on Windows. Also used a pop-up window to choose the circuit .json file, rather than hardcoding into the code. For now I've only made edits to the DiodeClipper example, but I can copy these changes to the other examples and template if they look okay to you!